### PR TITLE
Add locale.ENGLISH into getWaypointsFormatted

### DIFF
--- a/directions/lib/src/main/java/com/mapbox/directions/MapboxDirections.java
+++ b/directions/lib/src/main/java/com/mapbox/directions/MapboxDirections.java
@@ -153,7 +153,7 @@ public class MapboxDirections {
             // Convert to {lon},{lat} coordinate pairs
             List<String> pieces = new ArrayList<>();
             for (Waypoint waypoint: _waypoints) {
-                pieces.add(String.format("%f,%f", waypoint.getLongitude(), waypoint.getLatitude()));
+                pieces.add(String.format(Locale.ENGLISH, "%f,%f", waypoint.getLongitude(), waypoint.getLatitude()));
             }
 
             // The waypoints parameter should be a semicolon-separated list of locations to visit


### PR DESCRIPTION
Not specifying a locale in string.format is a source of bugs :) We are developing from Spain, that was the case: in one development real device the generated request URI has commas as lat/long separator (dot needed). We have tested and everything is OK now with this little change.